### PR TITLE
Event resources now support an optional end time.

### DIFF
--- a/lib/events/schedule_view.dart
+++ b/lib/events/schedule_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:web_app/common.dart';
 import 'package:web_app/time.dart';
 
 import 'schedule.dart';
@@ -29,13 +28,7 @@ class ScheduleOnceView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      filterJoin([
-        longDateFormat.format(schedule.date),
-        if (schedule.time != null) schedule.time!.format(context),
-        if (schedule.timeZone != null) '(${schedule.timeZone})',
-      ], separator: ' ')!,
-    );
+    return Text(schedule.format(schedule.date));
   }
 }
 
@@ -46,12 +39,7 @@ class ScheduleRecurringView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final started = filterJoin([
-      longDateFormat.format(schedule.date),
-      if (schedule.time != null) schedule.time!.format(context),
-      if (schedule.timeZone != null) '(${schedule.timeZone})',
-    ], separator: ' ')!;
-
+    String started = schedule.format(schedule.date);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/lib/time.dart
+++ b/lib/time.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'package:flutter/material.dart';
 
 import 'package:intl/intl.dart';
 
@@ -43,6 +44,10 @@ bool isLeapYear(int year) {
 int daysInMonth(int year, int month) {
   final dim = isLeapYear(year) ? _daysInMonthLeapYear : _daysInMonthNormalYear;
   return dim[month - 1];
+}
+
+int toMinuteOfDay(TimeOfDay time) {
+  return time.hour * 60 + time.minute;
 }
 
 enum Frequency implements HasLabel {


### PR DESCRIPTION
Change is pretty straightforward -- added a form field and display logic in the detail and summary resource view. Of course this adds `endTime` to the schedule schema, but it's optional so should be backwards compatible.

Summary view:
![Screenshot_20240126_123931](https://github.com/CANIS-NAU/QIResourceResilienceDB/assets/6167443/e3db319a-905c-4607-8322-a1e025bbc5a0)

Details view:
![Screenshot_20240126_124012](https://github.com/CANIS-NAU/QIResourceResilienceDB/assets/6167443/13030246-8b86-4f95-85d9-71cda156cc0d)

Form view:
![Screenshot_20240126_124201](https://github.com/CANIS-NAU/QIResourceResilienceDB/assets/6167443/211dd87a-bb77-4cdb-b3fe-4f9b6bd5d460)

